### PR TITLE
feat: allow voice actors to manage their own profile

### DIFF
--- a/apps/mobile/src/components/profile/WorkItem.vue
+++ b/apps/mobile/src/components/profile/WorkItem.vue
@@ -23,6 +23,7 @@
     </ion-label>
 
     <ion-button
+      v-if="canEdit"
       slot="end"
       fill="clear"
       size="small"
@@ -32,6 +33,7 @@
     </ion-button>
 
     <ion-button
+      v-if="canEdit"
       slot="end"
       fill="clear"
       size="small"
@@ -57,9 +59,12 @@ import { trash, create } from 'ionicons/icons';
 
 interface Props {
   workEntry: WorkEntry
+  canEdit?: boolean
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  canEdit: true
+})
 
 onMounted(() => {
     console.log('props.workEntry', props.workEntry)

--- a/apps/mobile/src/components/profile/WorkList.vue
+++ b/apps/mobile/src/components/profile/WorkList.vue
@@ -5,6 +5,7 @@
         v-for="workEntry in workEntries"
         :key="workEntry.id"
         :work-entry="workEntry"
+        :can-edit="canEdit"
         @edit="handleEditWork"
         @delete="handleDeleteWork"
       />
@@ -20,6 +21,10 @@ import WorkItem from './WorkItem.vue'
 import type { WorkEntry } from '@/stores/profile'
 
 const profileStore = useProfileStore()
+
+const props = defineProps<{
+  canEdit?: boolean
+}>()
 
 const workEntries = computed(() => profileStore.workEntries)
 

--- a/apps/mobile/src/locales/en.json
+++ b/apps/mobile/src/locales/en.json
@@ -32,7 +32,8 @@
     "downvote": "Downvote",
     "setStatus": "Set Status",
     "newVoiceActorsAdded": "{count} new voice actors added",
-    "noNewChangesFound": "No new changes found"
+    "noNewChangesFound": "No new changes found",
+    "suggestChanges": "Suggest changes (Coming soon)"
   },
   "profile": {
     "userProfile": "My User Profile",

--- a/apps/mobile/src/locales/fr.json
+++ b/apps/mobile/src/locales/fr.json
@@ -31,7 +31,8 @@
     "downvote": "Vote négatif",
     "setStatus": "Définir le statut",
     "newVoiceActorsAdded": "{count} nouveaux doubleurs ajoutés",
-    "noNewChangesFound": "Aucun nouveau changement trouvé"
+    "noNewChangesFound": "Aucun nouveau changement trouvé",
+    "suggestChanges": "Suggérer des modifications (Bientôt disponible)"
   },
   "profile": {
     "userProfile": "Mon profil utilisateur",

--- a/apps/mobile/src/views/voice-actor-details.vue
+++ b/apps/mobile/src/views/voice-actor-details.vue
@@ -6,7 +6,11 @@
           <ion-back-button :default-href="{ name: 'Home' }" />
         </ion-buttons>
         <ion-title>Voix</ion-title>
-
+        <ion-buttons slot="end">
+          <ion-button @click="openEditProfile">
+            <ion-icon :icon="create" slot="icon-only"></ion-icon>
+          </ion-button>
+        </ion-buttons>
       </ion-toolbar>
     </ion-header>
     <ion-content>
@@ -37,7 +41,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 // Admin check: get user from supabase.auth and check for admin role
 import type { Serie as SerieModel } from "@supabase/functions/_shared/serie";
 import {
@@ -49,7 +53,9 @@ import {
   IonToolbar,
   IonContent,
   IonHeader,
+  IonIcon
 } from "@ionic/vue";
+import { create } from 'ionicons/icons';
 import type { Movie as MovieModel } from "@supabase/functions/_shared/movie";
 import { supabase } from "../api/supabase";
 import VoiceActorHeader from "@/components/VoiceActorHeader.vue";
@@ -64,6 +70,7 @@ import { actorToPersonData } from "@/utils/convert";
 
 const authStore = useAuthStore();
 const route = useRoute();
+const router = useRouter();
 
 // Local admin check using Supabase auth
 
@@ -161,6 +168,11 @@ const baseEnhancedWork = computed<EnhancedWorkItem[]>(() => {
 
   return result;
 });
+
+const openEditProfile = () => {
+  const id = route.params.id;
+  router.push({ name: 'VoiceActorProfile', params: { id } });
+};
 
 // For chronological view
 const enhancedWork = computed(() => {

--- a/apps/mobile/src/views/voice-actor-profile.vue
+++ b/apps/mobile/src/views/voice-actor-profile.vue
@@ -30,31 +30,35 @@
         <div v-if="profileStore.hasProfile && editableProfile">
           <ion-list>
             <ion-item>
-              <ion-input label="First name" label-placement="stacked" v-model="(editableProfile as any).firstname"></ion-input>
+              <ion-input label="First name" label-placement="stacked" v-model="(editableProfile as any).firstname" :readonly="!canEdit"></ion-input>
             </ion-item>
             <ion-item>
-              <ion-input label="Last name" label-placement="stacked" v-model="(editableProfile as any).lastname"></ion-input>
+              <ion-input label="Last name" label-placement="stacked" v-model="(editableProfile as any).lastname" :readonly="!canEdit"></ion-input>
             </ion-item>
             <ion-item>
-              <ion-textarea label="Biography" label-placement="stacked" v-model="editableProfile.bio" :auto-grow="true"></ion-textarea>
+              <ion-textarea label="Biography" label-placement="stacked" v-model="editableProfile.bio" :auto-grow="true" :readonly="!canEdit"></ion-textarea>
             </ion-item>
             <ion-item>
-              <ion-input label="Nationality" label-placement="stacked" v-model="editableProfile.nationality"></ion-input>
+              <ion-input label="Nationality" label-placement="stacked" v-model="editableProfile.nationality" :readonly="!canEdit"></ion-input>
             </ion-item>
             <ion-item>
-              <ion-input type="date" label="Date of birth" label-placement="stacked" v-model="editableProfile.date_of_birth"></ion-input>
+              <ion-input type="date" label="Date of birth" label-placement="stacked" v-model="editableProfile.date_of_birth" :readonly="!canEdit"></ion-input>
             </ion-item>
             <ion-item>
-              <ion-input label="Awards" label-placement="stacked" v-model="(editableProfile as any).awards"></ion-input>
+              <ion-input label="Awards" label-placement="stacked" v-model="(editableProfile as any).awards" :readonly="!canEdit"></ion-input>
             </ion-item>
             <ion-item>
-              <ion-input label="Years active" label-placement="stacked" v-model="(editableProfile as any).years_active"></ion-input>
+              <ion-input label="Years active" label-placement="stacked" v-model="(editableProfile as any).years_active" :readonly="!canEdit"></ion-input>
             </ion-item>
           </ion-list>
 
-          <ion-button expand="block" @click="handleSave" :disabled="profileStore.isUpdating">
+          <ion-button v-if="canEdit" expand="block" @click="handleSave" :disabled="profileStore.isUpdating">
             <LoadingSpinner v-if="profileStore.isUpdating" name="crescent" inline />
             Save changes
+          </ion-button>
+          <ion-button v-else expand="block" fill="outline" disabled>
+            <!-- TODO: Implement Suggest Changes feature -->
+            {{ $t('common.suggestChanges') }}
           </ion-button>
 
           <div class="work-section">
@@ -64,7 +68,7 @@
                 <ion-icon slot="icon-only" :icon="add"></ion-icon>
               </ion-button>
             </div>
-            <WorkList @delete="handleDeleteWork" />
+            <WorkList :can-edit="canEdit" @delete="handleDeleteWork" />
           </div>
         </div>
 
@@ -128,7 +132,7 @@ const voiceActorId = computed(() => {
 })
 
 const canEdit = computed(() => {
-  return authStore.isAdmin || true // Voice actor profiles can be edited by their owners
+  return authStore.isAdmin || profileStore.voiceActors.some((va: any) => va.id === voiceActorId.value)
 })
 
 


### PR DESCRIPTION
Restrict the ability to edit a voice actor's profile to administrators and verified users linked to that account. For unauthorized users, display a read-only view and a disabled "Suggest changes" button. Added a shortcut button from the public profile view to access the edit page.

---
*PR created automatically by Jules for task [7648097785052423399](https://jules.google.com/task/7648097785052423399) started by @Armaldio*