### PR TITLE
chore(supabase): add missing Edge Functions to config.toml

### DIFF
--- a/packages/database/supabase/config.toml
+++ b/packages/database/supabase/config.toml
@@ -355,13 +355,28 @@ verify_jwt = true
 [functions.episode]
 verify_jwt = false
 
+[functions.extract-credits-from-image]
+verify_jwt = false
+
+[functions.extract-voice-actor-info]
+verify_jwt = false
+
 [functions.find_duplicate_voice_actors]
 verify_jwt = true
 
 [functions.find_duplicate_work]
 verify_jwt = true
 
+[functions.get-dubbing-project]
+verify_jwt = false
+
 [functions.get-media-credits]
+verify_jwt = false
+
+[functions.get-metadata]
+verify_jwt = false
+
+[functions.get-studio-details]
 verify_jwt = false
 
 [functions.get-user-profile]
@@ -388,6 +403,9 @@ verify_jwt = false
 [functions.list_users]
 verify_jwt = true
 
+[functions.media-queue]
+verify_jwt = false
+
 [functions.merge_voice_actor_duplicates]
 verify_jwt = true
 
@@ -403,10 +421,25 @@ verify_jwt = false
 [functions.prepare_voice_actor]
 verify_jwt = false
 
+[functions.process-credits]
+verify_jwt = false
+
 [functions.process-media-queue]
 verify_jwt = false
 
 [functions.recent-voice-actors]
+verify_jwt = false
+
+[functions.request-voice-actor-page]
+verify_jwt = true
+
+[functions.save-dubbing-project]
+verify_jwt = false
+
+[functions.save-metadata]
+verify_jwt = false
+
+[functions.save-studio]
 verify_jwt = false
 
 [functions.search]
@@ -454,11 +487,3 @@ verify_jwt = true
 [functions.voice-actor]
 verify_jwt = false
 
-[functions.request-voice-actor-page]
-verify_jwt = true
-
-[functions.extract-voice-actor-info]
-verify_jwt = false
-
-[functions.extract-credits-from-image]
-verify_jwt = false


### PR DESCRIPTION
Fixed an issue where `packages/database/check-functions.sh` was failing in CI due to several missing Edge Functions in `supabase/config.toml`. I added the missing functions (`get-studio-details`, `get-dubbing-project`, `get-metadata`, `save-dubbing-project`, `media-queue`, `save-metadata`, `save-studio`, and `process-credits`) with `verify_jwt = false`, and alphabetized the configuration of all functions for maintainability.

---
*PR created automatically by Jules for task [2453004478350747757](https://jules.google.com/task/2453004478350747757) started by @Armaldio*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated local endpoint authentication settings.
  * Added configuration for image and voice extraction, media processing, saving, and queue operations.
  * Preserved authentication requirements for protected voice actor requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->