### PR TITLE
feat: display movie collection on movie details page

### DIFF
--- a/apps/mobile/src/components/CollectionCard.vue
+++ b/apps/mobile/src/components/CollectionCard.vue
@@ -1,0 +1,171 @@
+<template>
+  <div v-if="collection" class="collection-container">
+    <div class="collection-card" @click="isOpen = true">
+      <div
+        class="collection-backdrop"
+        :style="{ backgroundImage: `url(${collection.backdrop_path || collection.poster_path})` }"
+      >
+        <div class="backdrop-gradient"></div>
+      </div>
+      <div class="collection-content">
+        <h2 class="collection-title">{{ collection.name }}</h2>
+        <div class="collection-meta">
+          <span class="meta-badge">{{ partsCount }} films</span>
+        </div>
+      </div>
+    </div>
+
+    <ion-modal :is-open="isOpen" @didDismiss="isOpen = false" :initial-breakpoint="0.8" :breakpoints="[0, 0.5, 0.8, 1]">
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>{{ collection.name }}</ion-title>
+          <ion-buttons slot="end">
+            <ion-button @click="isOpen = false">Fermer</ion-button>
+          </ion-buttons>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <p v-if="collection.overview" class="collection-overview">{{ collection.overview }}</p>
+
+        <h3 class="movies-title">Films dans cette collection</h3>
+        <div class="movies-list">
+          <MediaItem
+            v-for="part in collection.parts"
+            :key="part.id"
+            :imagePath="part.poster_path || undefined"
+            :title="part.title"
+            routeName="MovieDetails"
+            :routeParams="{ id: part.id }"
+            @click="isOpen = false"
+          />
+        </div>
+      </ion-content>
+    </ion-modal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { IonModal, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton, IonContent } from '@ionic/vue';
+import MediaItem from './MediaItem.vue';
+
+interface Movie {
+  id: number;
+  title: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  release_date: string;
+  overview: string;
+}
+
+interface Collection {
+  id: number;
+  name: string;
+  overview: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  parts: Movie[];
+}
+
+const props = defineProps<{
+  collection?: Collection | null;
+}>();
+
+const isOpen = ref(false);
+
+const partsCount = computed(() => {
+  return props.collection?.parts?.length || 0;
+});
+</script>
+
+<style scoped lang="scss">
+.collection-container {
+  margin: 16px;
+}
+
+.collection-card {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  height: 120px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--app-overlay-10);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
+.collection-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-size: cover;
+  background-position: center;
+  z-index: 0;
+}
+
+.backdrop-gradient {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: linear-gradient(
+    to right,
+    rgba(18, 18, 18, 0.9) 0%,
+    rgba(18, 18, 18, 0.6) 50%,
+    rgba(18, 18, 18, 0.4) 100%
+  );
+}
+
+.collection-content {
+  position: relative;
+  z-index: 1;
+  padding: 16px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.collection-title {
+  margin: 0 0 8px 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.meta-badge {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  backdrop-filter: blur(4px);
+  display: inline-block;
+}
+
+.collection-overview {
+  color: var(--app-color-text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin-bottom: 24px;
+}
+
+.movies-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.movies-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 16px;
+  padding-bottom: 32px;
+}
+</style>

--- a/apps/mobile/src/views/movie-details.vue
+++ b/apps/mobile/src/views/movie-details.vue
@@ -25,6 +25,8 @@
       </ion-refresher>
         <MediaInfoCard :media="movie" />
 
+        <CollectionCard v-if="collection" :collection="collection" />
+
         <DubbingProjectsView
           :contentId="route.params.id as string"
           contentType="movie"
@@ -118,6 +120,7 @@ import { storeToRefs } from "pinia";
 import { useAuthStore } from "@/stores/auth";
 import MediaInfoCard from "@/components/MediaInfoCard.vue";
 import DubbingProjectsView from "@/components/DubbingProjectsView.vue";
+import CollectionCard from "@/components/CollectionCard.vue";
 import PersonSearchModal from "@/components/PersonSearchModal.vue";
 import CreditsReviewModal from "@/components/CreditsReviewModal.vue";
 import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
@@ -208,6 +211,7 @@ const {
 } = useVoiceActorManagement("movie");
 
 const movie = ref<MovieResponse["movie"] | undefined>();
+const collection = ref<MovieResponse["collection"] | null>(null);
 const dubbingProjects = ref<Array<{ id: number; works?: unknown[] }>>([]);
 const queueStatus = ref<string | null>(null);
 const queueErrorMessage = ref<string | null>(null);
@@ -580,6 +584,9 @@ const fetchMovieData = async () => {
       dubbingProjects.value = data.dubbingProjects || [];
       if (data.characterProfilePictures) {
         characterProfilePictures.value = data.characterProfilePictures;
+      }
+      if (data.collection) {
+        collection.value = data.collection;
       }
 
       // Hydrate shared votes store

--- a/packages/database/supabase/functions/_shared/interfaces.ts
+++ b/packages/database/supabase/functions/_shared/interfaces.ts
@@ -9,6 +9,7 @@ export interface ITMDBClient {
   ): Promise<any>;
   fetchMediaDetails(contentId: number, contentType: string): Promise<any>;
   fetchMediaCredits(mediaType: string, mediaId: number): Promise<any>;
+  getCollection(collectionId: number): Promise<any>;
   getCached?(endpoint: string, params?: Record<string, string>): Promise<any>;
   setCache?(key: string, data: any, ttl: string): Promise<void>;
   clearCache?(key: string): Promise<void>;

--- a/packages/database/supabase/functions/_shared/media-service.ts
+++ b/packages/database/supabase/functions/_shared/media-service.ts
@@ -240,10 +240,27 @@ export class MediaService {
       contentId,
     );
 
+    let collection = null;
+    if (contentType === "movie" && media.belongs_to_collection?.id) {
+      const collectionData = await this.tmdbClient.getCollection(media.belongs_to_collection.id);
+      if (collectionData) {
+        collection = {
+          ...collectionData,
+          backdrop_path: collectionData.backdrop_path ? `https://image.tmdb.org/t/p/w500${collectionData.backdrop_path}` : null,
+          poster_path: collectionData.poster_path ? `https://image.tmdb.org/t/p/w500${collectionData.poster_path}` : null,
+          parts: collectionData.parts ? collectionData.parts.map((part: any) => ({
+            ...part,
+            backdrop_path: part.backdrop_path ? `https://image.tmdb.org/t/p/w500${part.backdrop_path}` : null,
+            poster_path: part.poster_path ? `https://image.tmdb.org/t/p/w500${part.poster_path}` : null,
+          })) : []
+        };
+      }
+    }
+
     // Process image URLs in the media data
     const processedMedia = processMedia(media);
 
-    return { media: processedMedia };
+    return { media: processedMedia, collection };
   }
 
   async getMediaWithVoiceActorsExtended(

--- a/packages/database/supabase/functions/_shared/tmdb.ts
+++ b/packages/database/supabase/functions/_shared/tmdb.ts
@@ -169,4 +169,24 @@ export class TMDBClient implements ITMDBClient {
   async fetchMediaCredits(mediaType: string, mediaId: number) {
     return await this.get(`${mediaType}/${mediaId}/credits`);
   }
+
+  async getCollection(collectionId: number) {
+    const cacheKey = this.cache.tmdbKey('collection', collectionId, "details");
+
+    // Try cache first
+    const cached = await this.cache.get(cacheKey);
+    if (cached) {
+      debugLog(`TMDB cache hit for collection ${collectionId}`);
+      return cached;
+    }
+
+    // Cache miss - fetch from API
+    const result = await this.get(`collection/${collectionId}`);
+
+    // Cache the result with MEDIUM TTL (6 hours for media details)
+    await this.cache.set(cacheKey, result, "MEDIUM");
+    debugLog(`TMDB cache set for collection ${collectionId}`);
+
+    return result;
+  }
 }

--- a/packages/database/supabase/functions/_shared/types.ts
+++ b/packages/database/supabase/functions/_shared/types.ts
@@ -15,6 +15,12 @@ export interface Movie {
   video: boolean;
   vote_average: number;
   vote_count: number;
+  belongs_to_collection?: {
+    id: number;
+    name: string;
+    poster_path: string;
+    backdrop_path: string;
+  };
 }
 
 export interface TrendingResponse {
@@ -61,6 +67,14 @@ export interface MovieResponse {
   }>;
   dubbingProjects?: any[];
   votes?: Record<number, any>;
+  collection?: {
+    id: number;
+    name: string;
+    overview: string;
+    poster_path: string;
+    backdrop_path: string;
+    parts: Movie[];
+  };
 }
 
 // Series-related types

--- a/packages/database/supabase/functions/movie/index.ts
+++ b/packages/database/supabase/functions/movie/index.ts
@@ -52,6 +52,7 @@ export default {
           return {
             movieWithImageUrls: result.media,
             characterProfilePictures,
+            collection: result.collection,
           };
         })
         .catch((err) => {
@@ -75,6 +76,7 @@ export default {
           return {
             movieWithImageUrls: processMedia(mockMovie),
             characterProfilePictures: [],
+            collection: null,
           };
         });
 
@@ -113,13 +115,14 @@ export default {
         dbDataPromise,
       ]);
 
-      const { movieWithImageUrls, characterProfilePictures } = apiData;
+      const { movieWithImageUrls, characterProfilePictures, collection } = apiData;
 
       const result = {
         movie: movieWithImageUrls,
         characterProfilePictures: characterProfilePictures,
         dubbingProjects: dubbingProjects,
         votes: voteData,
+        collection: collection,
       };
 
       return Response.json(result);


### PR DESCRIPTION
This PR adds a feature to display a movie's collection on the movie details page. If a movie belongs to a TMDB collection, a card with the collection's details is shown. Clicking this card opens a modal containing the list of all movies in that collection, which can be clicked to navigate to their respective details pages.

---
*PR created automatically by Jules for task [4013608437033790146](https://jules.google.com/task/4013608437033790146) started by @Armaldio*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Movie details now display collection information, including the collection name, film count, overview, and related films.
  * Collection films can be browsed in a dedicated modal with tappable media items.
  * Movie data now includes collection details when available.
* **Bug Fixes**
  * Collection artwork is displayed with correctly formatted image URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->