### PR TITLE
fix(mobile): Support extended deep link routes and alphanumeric IDs

### DIFF
--- a/apps/mobile/src/utils/deepLinks.ts
+++ b/apps/mobile/src/utils/deepLinks.ts
@@ -1,6 +1,6 @@
 import { useRouter } from "vue-router";
 
-type DeepLinkType = "movie" | "show";
+type DeepLinkType = "movie" | "show" | "actor" | "voice-actor";
 
 interface DeepLink {
   type: DeepLinkType;
@@ -11,8 +11,8 @@ export function parseDeepLink(url: string): DeepLink | null {
   try {
     // Handle both dubbingbase:// and dubbingbase:/ formats
     const match =
-      url.match(/^dubbingbase:\/\/(movie|show)\/(\d+)/i) ||
-      url.match(/^dubbingbase:\/(movie|show)\/(\d+)/i);
+      url.match(/^dubbingbase:\/\/(movie|show|actor|voice-actor)\/([a-zA-Z0-9_-]+)/i) ||
+      url.match(/^dubbingbase:\/(movie|show|actor|voice-actor)\/([a-zA-Z0-9_-]+)/i);
 
     if (match) {
       return {
@@ -42,6 +42,12 @@ export function useDeepLinkHandler() {
         return true;
       case "show":
         router.push({ name: "SerieDetails", params: { id } });
+        return true;
+      case "actor":
+        router.push({ name: "ActorDetails", params: { id } });
+        return true;
+      case "voice-actor":
+        router.push({ name: "voice-actor-details", params: { id } });
         return true;
       default:
         return false;


### PR DESCRIPTION
Fixes the mobile deep linking functionality so that "Open in App" links from the landing page reliably resolve in the app. Updates the internal parser to understand actor and voice-actor routes, and handles alphanumeric IDs instead of restricting solely to integers.

---
*PR created automatically by Jules for task [16782742662464312870](https://jules.google.com/task/16782742662464312870) started by @Armaldio*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deep links to actor and voice actor profiles.
  * IDs in these links can now include letters, numbers, underscores, and hyphens.
  * Links open the corresponding profile details screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->