### PR TITLE
Add llms.txt for Website

### DIFF
--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -4,6 +4,6 @@
 
 This website provides a web interface for the DubbingBase platform, featuring data grids and analytics.
 
-## Features
+Features:
 - **Browse Database**: Explore movies, TV shows, and voice actor profiles.
 - **Data Grids & Analytics**: Advanced tools to view and analyze dubbing information.

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -1,0 +1,9 @@
+# DubbingBase Website
+
+> DubbingBase is a comprehensive platform dedicated to tracking and managing dubbing information for movies and TV shows. It serves as a database for voice actors, their roles, and the productions they are involved in.
+
+This website provides a web interface for the DubbingBase platform, featuring data grids and analytics.
+
+## Features
+- **Browse Database**: Explore movies, TV shows, and voice actor profiles.
+- **Data Grids & Analytics**: Advanced tools to view and analyze dubbing information.


### PR DESCRIPTION
Added `llms.txt` file to the `apps/website/public` directory to provide standard LLM-friendly context for the DubbingBase website, following the llmstxt.org specification.

---
*PR created automatically by Jules for task [2900574250840420639](https://jules.google.com/task/2900574250840420639) started by @Armaldio*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an AI-readable overview of DubbingBase, including its website interface, dubbing data browsing features, and analytics tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->