### PR TITLE
Refactor website data fetching to use SSR to eliminate loading skeletons

### DIFF
--- a/apps/website/src/pages/game/[id].vue
+++ b/apps/website/src/pages/game/[id].vue
@@ -285,7 +285,7 @@ const isAdmin = computed(() => {
 
 const isPreparing = ref(false);
 
-const { data, pending, refresh } = useAsyncData(`game-${gameId}`, () => fetchGameData(supabase, gameId), { lazy: true });
+const { data, pending, refresh } = useAsyncData(`game-${gameId}`, () => fetchGameData(supabase, gameId));
 
 const { locale, t } = useI18n();
 

--- a/apps/website/src/pages/index.vue
+++ b/apps/website/src/pages/index.vue
@@ -280,7 +280,7 @@ useHead({
   ],
 });
 
-const { data, pending } = useAsyncData('home-data', () => fetchHomeData(supabase), { lazy: true });
+const { data, pending } = useAsyncData('home-data', () => fetchHomeData(supabase));
 
 const trendingMovies = computed(() => data.value?.trendingMovies || []);
 const trendingSeries = computed(() => data.value?.trendingSeries || []);

--- a/apps/website/src/pages/movie/[id].vue
+++ b/apps/website/src/pages/movie/[id].vue
@@ -382,8 +382,7 @@ const isAdmin = computed(() => {
 });
 
 const { data, pending } = useAsyncData(`movie-${movieId}`, () =>
-  fetchMovieData(supabase, movieId),
-  { lazy: true }
+  fetchMovieData(supabase, movieId)
 );
 
 const { locale, t } = useI18n();

--- a/apps/website/src/pages/movies.vue
+++ b/apps/website/src/pages/movies.vue
@@ -43,14 +43,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { computed } from 'vue';
 
 const supabase = useSupabaseClient();
 const { t } = useI18n();
-
-const movies = ref<any[]>([]);
-const isLoading = ref(true);
-const error = ref('');
 
 useHead({
   title: 'Tous les Films - DubbingBase',
@@ -66,16 +62,11 @@ useHead({
   ]
 });
 
-onMounted(async () => {
-  try {
-    const { data, error: fetchError } = await supabase.functions.invoke('trending-movies');
-    if (fetchError) throw fetchError;
-    
-    movies.value = data?.results || [];
-  } catch (err: any) {
-    error.value = err.message || 'Une erreur est survenue lors du chargement des films.';
-  } finally {
-    isLoading.value = false;
-  }
+const { data, pending: isLoading, error } = useAsyncData('movies-page', async () => {
+  const { data, error: fetchError } = await supabase.functions.invoke('trending-movies');
+  if (fetchError) throw fetchError;
+  return data?.results || [];
 });
+
+const movies = computed(() => data.value || []);
 </script>

--- a/apps/website/src/pages/series.vue
+++ b/apps/website/src/pages/series.vue
@@ -43,14 +43,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { computed } from 'vue';
 
 const supabase = useSupabaseClient();
 const { t } = useI18n();
-
-const series = ref<any[]>([]);
-const isLoading = ref(true);
-const error = ref('');
 
 useHead({
   title: 'Toutes les Séries - DubbingBase',
@@ -66,16 +62,11 @@ useHead({
   ]
 });
 
-onMounted(async () => {
-  try {
-    const { data, error: fetchError } = await supabase.functions.invoke('trending-shows');
-    if (fetchError) throw fetchError;
-    
-    series.value = data?.results || [];
-  } catch (err: any) {
-    error.value = err.message || 'Une erreur est survenue lors du chargement des séries.';
-  } finally {
-    isLoading.value = false;
-  }
+const { data, pending: isLoading, error } = useAsyncData('series-page', async () => {
+  const { data, error: fetchError } = await supabase.functions.invoke('trending-shows');
+  if (fetchError) throw fetchError;
+  return data?.results || [];
 });
+
+const series = computed(() => data.value || []);
 </script>

--- a/apps/website/src/pages/show/[id].vue
+++ b/apps/website/src/pages/show/[id].vue
@@ -391,8 +391,7 @@ const isAdmin = computed(() => {
 });
 
 const { data, pending } = useAsyncData(`show-${showId}`, () =>
-  fetchShowData(supabase, showId),
-  { lazy: true }
+  fetchShowData(supabase, showId)
 );
 
 const { locale, t } = useI18n();

--- a/apps/website/src/pages/voice-actor/[id].vue
+++ b/apps/website/src/pages/voice-actor/[id].vue
@@ -316,7 +316,7 @@ const { locale, t } = useI18n();
 const config = useRuntimeConfig();
 const baseUrl = config.public.supabase.url;
 
-const { data, pending } = useAsyncData(`voice-actor-${voiceActorId}`, () => fetchVoiceActorData(supabase, voiceActorId), { lazy: true });
+const { data, pending } = useAsyncData(`voice-actor-${voiceActorId}`, () => fetchVoiceActorData(supabase, voiceActorId));
 
 const voiceActorData = useVoiceActorData(supabase, data.value);
 const {

--- a/apps/website/src/pages/voice-actors.vue
+++ b/apps/website/src/pages/voice-actors.vue
@@ -71,14 +71,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed } from 'vue';
 
 const supabase = useSupabaseClient();
 const { t } = useI18n();
 
-const allActors = ref<any[]>([]);
-const isLoading = ref(true);
-const error = ref('');
 const searchQuery = ref('');
 
 useHead({
@@ -95,6 +92,14 @@ useHead({
   ]
 });
 
+const { data, pending: isLoading, error } = useAsyncData('voice-actors-page', async () => {
+  const { data, error: fetchError } = await supabase.functions.invoke('list-voice-actors');
+  if (fetchError) throw fetchError;
+  return data?.voice_actors || [];
+});
+
+const allActors = computed(() => data.value || []);
+
 // Filtrage local simple
 const filteredActors = computed(() => {
   if (!searchQuery.value.trim()) return allActors.value;
@@ -103,18 +108,5 @@ const filteredActors = computed(() => {
     const fullName = `${actor.firstname} ${actor.lastname}`.toLowerCase();
     return fullName.includes(query);
   });
-});
-
-onMounted(async () => {
-  try {
-    const { data, error: fetchError } = await supabase.functions.invoke('list-voice-actors');
-    if (fetchError) throw fetchError;
-    
-    allActors.value = data?.voice_actors || [];
-  } catch (err: any) {
-    error.value = err.message || 'Une erreur est survenue lors du chargement des comédiens.';
-  } finally {
-    isLoading.value = false;
-  }
 });
 </script>


### PR DESCRIPTION
This PR modifies how data is fetched on the Nuxt website to improve perceived performance and eliminate long-lasting loading skeletons.

- Removed `lazy: true` from `useAsyncData` calls to ensure the server waits for the data before rendering and returning the HTML.
- Converted client-side `onMounted` data fetching to standard `useAsyncData` on listing pages (`/movies`, `/series`, `/voice-actors`).

The website will now render fully populated pages instantly, eliminating the noticeable skeleton loading states that the user complained about.

---
*PR created automatically by Jules for task [17320264079034201539](https://jules.google.com/task/17320264079034201539) started by @Armaldio*