### PR TITLE
ci: add changesets action for automated version bumps

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -331,3 +331,31 @@ jobs:
           workingDirectory: apps/website
           command: pages deploy ./dist --project-name=dubbingbase-website --branch=${{ github.head_ref || github.ref_name }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  # Job 8: Create/Update Version PR
+  version:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `changesets/action` to `.github/workflows/pipeline.yml` to automate version bumping.

This introduces a new `version` job in the existing `pipeline.yml` that:
- Runs when code is pushed to the `main` branch.
- Checks out the code and sets up `pnpm`.
- Uses `changesets/action@v2` with `GITHUB_TOKEN` to generate/update Version PRs based on the available changesets.
- Does not publish to npm, as requested, since only application deployments are required.

---
*PR created automatically by Jules for task [2001249965919442678](https://jules.google.com/task/2001249965919442678) started by @Armaldio*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release pull request creation for changes merged into the main branch.
  * Release updates now run automatically after qualifying pushes, with the required repository permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->