### PR TITLE
feat(website): add BreadcrumbList structured data and align OG/Twitter meta

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -145,7 +145,7 @@ This repo uses [Changesets](https://github.com/changesets/changesets) for versio
 
 When adding a **new feature** (or any user-facing change), generate a changeset before finishing the task:
 
-- Run `pnpm changeset` and answer the prompts, OR add a markdown file directly under `.changeset/` (do not edit `README.md` or `config.json`).
+- Run `pnpm exec changeset` and answer the prompts, OR add a markdown file directly under `.changeset/` (do not edit `README.md` or `config.json`).
 - Name the file anything unique, e.g. `.changeset/add-breadcrumb-structured-data.md`.
 - Format:
 
@@ -162,7 +162,7 @@ When adding a **new feature** (or any user-facing change), generate a changeset 
   - `patch` — bug fixes / chores
   - `major` — breaking change
 - One changeset file per logical change; avoid committing changeset files for internal-only refactors with no user-facing impact.
-- Never commit the changeset if the user only asked for a code change without a feature — but when a feature is added, a changeset is expected.
+- Skip the changeset only for internal-only refactors with no user-facing package impact, or when the user explicitly asks for a code-only change. User-facing fixes (`patch`) and features (`minor`) always require a changeset.
 
 ---
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -139,6 +139,33 @@ When you need to verify or debug external API data (e.g., missing character imag
 
 ---
 
+## 📦 Changesets
+
+This repo uses [Changesets](https://github.com/changesets/changesets) for versioning (`@changesets/cli` is installed, config in `.changeset/config.json`).
+
+When adding a **new feature** (or any user-facing change), generate a changeset before finishing the task:
+
+- Run `pnpm changeset` and answer the prompts, OR add a markdown file directly under `.changeset/` (do not edit `README.md` or `config.json`).
+- Name the file anything unique, e.g. `.changeset/add-breadcrumb-structured-data.md`.
+- Format:
+
+  ```md
+  ---
+  "name-of-package": minor
+  ---
+
+  Short description of the feature for the changelog.
+  ```
+
+- Use the correct bump type:
+  - `minor` — new feature (non-breaking)
+  - `patch` — bug fixes / chores
+  - `major` — breaking change
+- One changeset file per logical change; avoid committing changeset files for internal-only refactors with no user-facing impact.
+- Never commit the changeset if the user only asked for a code change without a feature — but when a feature is added, a changeset is expected.
+
+---
+
 ## 🤖 AI Agent Behavior Guidelines
 
 1. **Research First**: Before writing code, inspect existing files, imports, and state to understand the setup.

--- a/.changeset/add-breadcrumb-structured-data.md
+++ b/.changeset/add-breadcrumb-structured-data.md
@@ -1,0 +1,5 @@
+---
+"@app/website": minor
+---
+
+Add BreadcrumbList structured data (JSON-LD) to all pages and align Open Graph / Twitter meta with the page title. Replaces the restrictive "english voices" og:description with the generic site description to improve Google SERP breadcrumb display.

--- a/.changeset/add-breadcrumb-structured-data.md
+++ b/.changeset/add-breadcrumb-structured-data.md
@@ -2,4 +2,4 @@
 "@app/website": minor
 ---
 
-Add BreadcrumbList structured data (JSON-LD) to all pages and align Open Graph / Twitter meta with the page title. Replaces the restrictive "english voices" og:description with the generic site description to improve Google SERP breadcrumb display.
+Improve Google SERP presentation: add route-aware BreadcrumbList JSON-LD on all pages, align Open Graph / Twitter titles with the page title, replace the restrictive "english voices" og:description with the generic site description, and add site-name signals (global WebSite structured data with name/alternateName, `og:site_name`, and `application-name` meta) so Google shows "DubbingBase" as the site name instead of the raw URL.

--- a/apps/website/i18n/locales/en.json
+++ b/apps/website/i18n/locales/en.json
@@ -71,9 +71,7 @@
     "meta": {
       "title": "The Dubbing & Voice Actor Database",
       "description": "Discover the reference database for dubbing. Find voice actor profiles, their roles, and voice casts of your favorite movies and series.",
-      "keywords": "dubbing, voice actors, english voice, voice casts, movies, series, actor profiles",
-      "ogTitle": "The Dubbing Database",
-      "ogDescription": "Find the complete database of voice actors and english voices."
+      "keywords": "dubbing, voice actors, english voice, voice casts, movies, series, actor profiles"
     },
     "hero": {
       "title": "The Dubbing & Voice Actor Database",

--- a/apps/website/i18n/locales/en.json
+++ b/apps/website/i18n/locales/en.json
@@ -131,5 +131,30 @@
     "voice": "Voice",
     "songs": "Songs",
     "other": "Other"
+  },
+  "breadcrumb": {
+    "home": "Home",
+    "sections": {
+      "movies": "Movies",
+      "series": "Series",
+      "voiceActors": "Voice Actors",
+      "studios": "Studios",
+      "games": "Games",
+      "actors": "Actors",
+      "leaderboard": "Leaderboard",
+      "discussions": "Discussions",
+      "contribute": "Contribute",
+      "login": "Login",
+      "register": "Register",
+      "profile": "Profile",
+      "settings": "Settings",
+      "apiKey": "API Key",
+      "about": "About",
+      "legal": "Legal",
+      "privacy": "Privacy",
+      "terms": "Terms",
+      "termsApi": "API Terms",
+      "guidelines": "Guidelines"
+    }
   }
 }

--- a/apps/website/i18n/locales/fr.json
+++ b/apps/website/i18n/locales/fr.json
@@ -131,5 +131,30 @@
     "voice": "Voix",
     "songs": "Chansons",
     "other": "Autre"
+  },
+  "breadcrumb": {
+    "home": "Accueil",
+    "sections": {
+      "movies": "Films",
+      "series": "Séries",
+      "voiceActors": "Comédiens de doublage",
+      "studios": "Studios",
+      "games": "Jeux",
+      "actors": "Acteurs",
+      "leaderboard": "Classement",
+      "discussions": "Discussions",
+      "contribute": "Contribuer",
+      "login": "Connexion",
+      "register": "Inscription",
+      "profile": "Profil",
+      "settings": "Paramètres",
+      "apiKey": "Clé API",
+      "about": "À propos",
+      "legal": "Mentions légales",
+      "privacy": "Confidentialité",
+      "terms": "Conditions",
+      "termsApi": "Conditions de l'API",
+      "guidelines": "Directives"
+    }
   }
 }

--- a/apps/website/i18n/locales/fr.json
+++ b/apps/website/i18n/locales/fr.json
@@ -71,9 +71,7 @@
     "meta": {
       "title": "La base de données mondiale du doublage",
       "description": "Découvrez l'encyclopédie mondiale du doublage. Retrouvez les fiches des comédiens, leurs rôles et les castings vocaux de vos films et séries.",
-      "keywords": "doublage, comédiens de doublage, casting vocal, films, séries, fiches acteurs",
-      "ogTitle": "La base de données du doublage",
-      "ogDescription": "Retrouvez la base de données complète des comédiens de doublage du monde entier."
+      "keywords": "doublage, comédiens de doublage, casting vocal, films, séries, fiches acteurs"
     },
     "hero": {
       "title": "La base de données du doublage et des comédiens",

--- a/apps/website/src/app.vue
+++ b/apps/website/src/app.vue
@@ -46,10 +46,21 @@ useHead({
       type: 'application/ld+json',
       innerHTML: breadcrumbJsonLd,
     },
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: 'DubbingBase',
+        alternateName: 'Dubbing Base',
+        url: 'https://dubbingbase.com',
+      }).replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026'),
+    },
   ],
 });
 
 useSeoMeta({
-  ogSiteName: 'DubbingBase'
+  ogSiteName: 'DubbingBase',
+  applicationName: 'DubbingBase',
 });
 </script>

--- a/apps/website/src/app.vue
+++ b/apps/website/src/app.vue
@@ -21,6 +21,8 @@ const i18nHead = useLocaleHead({
   seo: true
 })
 
+const breadcrumbJsonLd = useBreadcrumbJsonLd();
+
 useHead({
   htmlAttrs: {
     'data-theme': effectiveTheme,
@@ -38,7 +40,13 @@ useHead({
     { rel: 'manifest', href: '/manifest.webmanifest' },
     ...(i18nHead.value.link || [])
   ],
-  meta: () => [...(i18nHead.value.meta || [])]
+  meta: () => [...(i18nHead.value.meta || [])],
+  script: [
+    {
+      type: 'application/ld+json',
+      innerHTML: breadcrumbJsonLd,
+    },
+  ],
 });
 
 useSeoMeta({

--- a/apps/website/src/composables/useBreadcrumbJsonLd.ts
+++ b/apps/website/src/composables/useBreadcrumbJsonLd.ts
@@ -1,0 +1,88 @@
+const SECTION_LABELS: Record<string, string> = {
+  movies: "Movies",
+  series: "Series",
+  "voice-actors": "Voice Actors",
+  studios: "Studios",
+  games: "Games",
+  movie: "Movies",
+  show: "Series",
+  game: "Games",
+  "voice-actor": "Voice Actors",
+  studio: "Studios",
+  actor: "Actors",
+  leaderboard: "Leaderboard",
+  discussions: "Discussions",
+  contribute: "Contribute",
+  login: "Login",
+  register: "Register",
+  profile: "Profile",
+  settings: "Settings",
+  "api-key": "API Key",
+  about: "About",
+  legal: "Legal",
+  privacy: "Privacy",
+  terms: "Terms",
+  "terms-api": "API Terms",
+  guidelines: "Guidelines",
+};
+
+const LOCALE_PREFIXES = ["fr"];
+
+function capitalize(value: string): string {
+  return value
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function sanitize(json: string): string {
+  return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
+}
+
+export function useBreadcrumbJsonLd() {
+  const route = useRoute();
+  const SITE = "https://dubbingbase.com";
+
+  const jsonLd = computed(() => {
+    const rawSegments = route.path.split("/").filter(Boolean);
+    const locale = LOCALE_PREFIXES.includes(rawSegments[0]) ? rawSegments[0] : "";
+    const segments = locale ? rawSegments.slice(1) : rawSegments;
+
+    const itemListElement: {
+      "@type": "ListItem";
+      position: number;
+      name: string;
+      item: string;
+    }[] = [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: locale ? `${SITE}/${locale}` : SITE,
+      },
+    ];
+
+    let acc = locale ? `/${locale}` : "";
+    let position = 2;
+    for (const segment of segments) {
+      acc += `/${segment}`;
+      const name = SECTION_LABELS[segment] ?? capitalize(decodeURIComponent(segment));
+      itemListElement.push({
+        "@type": "ListItem",
+        position,
+        name,
+        item: `${SITE}${acc}`,
+      });
+      position++;
+    }
+
+    return sanitize(
+      JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement,
+      }),
+    );
+  });
+
+  return jsonLd;
+}

--- a/apps/website/src/composables/useBreadcrumbJsonLd.ts
+++ b/apps/website/src/composables/useBreadcrumbJsonLd.ts
@@ -1,29 +1,29 @@
-const SECTION_LABELS: Record<string, string> = {
-  movies: "Movies",
-  series: "Series",
-  "voice-actors": "Voice Actors",
-  studios: "Studios",
-  games: "Games",
-  movie: "Movies",
-  show: "Series",
-  game: "Games",
-  "voice-actor": "Voice Actors",
-  studio: "Studios",
-  actor: "Actors",
-  leaderboard: "Leaderboard",
-  discussions: "Discussions",
-  contribute: "Contribute",
-  login: "Login",
-  register: "Register",
-  profile: "Profile",
-  settings: "Settings",
-  "api-key": "API Key",
-  about: "About",
-  legal: "Legal",
-  privacy: "Privacy",
-  terms: "Terms",
-  "terms-api": "API Terms",
-  guidelines: "Guidelines",
+const SECTION_I18N_KEYS: Record<string, string> = {
+  movies: "breadcrumb.sections.movies",
+  series: "breadcrumb.sections.series",
+  "voice-actors": "breadcrumb.sections.voiceActors",
+  studios: "breadcrumb.sections.studios",
+  games: "breadcrumb.sections.games",
+  movie: "breadcrumb.sections.movies",
+  show: "breadcrumb.sections.series",
+  game: "breadcrumb.sections.games",
+  "voice-actor": "breadcrumb.sections.voiceActors",
+  studio: "breadcrumb.sections.studios",
+  actor: "breadcrumb.sections.actors",
+  leaderboard: "breadcrumb.sections.leaderboard",
+  discussions: "breadcrumb.sections.discussions",
+  contribute: "breadcrumb.sections.contribute",
+  login: "breadcrumb.sections.login",
+  register: "breadcrumb.sections.register",
+  profile: "breadcrumb.sections.profile",
+  settings: "breadcrumb.sections.settings",
+  "api-key": "breadcrumb.sections.apiKey",
+  about: "breadcrumb.sections.about",
+  legal: "breadcrumb.sections.legal",
+  privacy: "breadcrumb.sections.privacy",
+  terms: "breadcrumb.sections.terms",
+  "terms-api": "breadcrumb.sections.termsApi",
+  guidelines: "breadcrumb.sections.guidelines",
 };
 
 const LOCALE_PREFIXES = ["fr"];
@@ -34,12 +34,21 @@ function capitalize(value: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function sanitize(json: string): string {
   return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
 }
 
 export function useBreadcrumbJsonLd() {
   const route = useRoute();
+  const { t } = useI18n();
   const SITE = "https://dubbingbase.com";
 
   const jsonLd = computed(() => {
@@ -56,7 +65,7 @@ export function useBreadcrumbJsonLd() {
       {
         "@type": "ListItem",
         position: 1,
-        name: "Home",
+        name: t("breadcrumb.home", "Home"),
         item: locale ? `${SITE}/${locale}` : SITE,
       },
     ];
@@ -65,7 +74,8 @@ export function useBreadcrumbJsonLd() {
     let position = 2;
     for (const segment of segments) {
       acc += `/${segment}`;
-      const name = SECTION_LABELS[segment] ?? capitalize(decodeURIComponent(segment));
+      const key = SECTION_I18N_KEYS[segment];
+      const name = key ? t(key) : capitalize(safeDecode(segment));
       itemListElement.push({
         "@type": "ListItem",
         position,

--- a/apps/website/src/pages/index.vue
+++ b/apps/website/src/pages/index.vue
@@ -230,32 +230,33 @@ useDragScroll(gamesScrollRef);
 useDragScroll(vaScrollRef);
 useDragScroll(contributorsScrollRef);
 
+const pageTitle = computed(() => {
+  // In FR: "La base de données mondiale du doublage | DubbingBase"
+  // In EN: "The Dubbing & Voice Actor Database | DubbingBase"
+  return `${t('home.meta.title')} | DubbingBase`;
+});
+
+const pageDescription = computed(() => {
+  const desc = t('home.meta.description');
+  return desc.length > 160 ? desc.substring(0, 157) + '...' : desc;
+});
+
 useHead({
   titleTemplate: null, // Override global titleTemplate to avoid duplicated DubbingBase
-  title: computed(() => {
-    // In FR: "La base de données mondiale du doublage | DubbingBase"
-    // In EN: "The Dubbing & Voice Actor Database | DubbingBase"
-    return `${t('home.meta.title')} | DubbingBase`;
-  }),
+  title: pageTitle,
   meta: [
     {
       name: 'description',
-      content: computed(() => {
-        const desc = t('home.meta.description');
-        return desc.length > 160 ? desc.substring(0, 157) + '...' : desc;
-      }),
+      content: pageDescription,
     },
     {
       name: 'keywords',
       content: computed(() => t('home.meta.keywords')),
     },
-    { property: 'og:title', content: computed(() => t('home.meta.ogTitle')) },
+    { property: 'og:title', content: pageTitle },
     {
       property: 'og:description',
-      content: computed(() => {
-        const desc = t('home.meta.ogDescription');
-        return desc.length > 160 ? desc.substring(0, 157) + '...' : desc;
-      }),
+      content: pageDescription,
     },
     { property: 'og:type', content: 'website' },
     { property: 'og:url', content: 'https://dubbingbase.com/' },
@@ -263,13 +264,10 @@ useHead({
     { property: 'og:site_name', content: 'DubbingBase' },
     { property: 'og:locale', content: ogLocale },
     { name: 'twitter:card', content: 'summary_large_image' },
-    { name: 'twitter:title', content: computed(() => t('home.meta.ogTitle')) },
+    { name: 'twitter:title', content: pageTitle },
     {
       name: 'twitter:description',
-      content: computed(() => {
-        const desc = t('home.meta.ogDescription');
-        return desc.length > 160 ? desc.substring(0, 157) + '...' : desc;
-      }),
+      content: pageDescription,
     },
     { name: 'twitter:image', content: 'https://dubbingbase.com/android-chrome-512x512.png' },
   ],


### PR DESCRIPTION
## Summary
- Adds route-aware `BreadcrumbList` JSON-LD to `<head>` on all pages (position, name, item URL per level) to fix Google showing the raw URL in SERPs.
- Aligns `og:title` / `twitter:title` with the actual `<title>` tag (previously divergent).
- Replaces the restrictive "english voices" `og:description` with the generic site description.
- Documents the changeset requirement in `.agents/AGENTS.md`.

## Changeset
`@app/website`: minor — `.changeset/add-breadcrumb-structured-data.md`

## Test plan
- [ ] Verify breadcrumb JSON-LD appears on home and section/detail pages.
- [ ] Verify `og:title`/`twitter:title` match the `<title>`.
- [ ] Submit URL in Google Search Console → Request Indexing and allow several days for recrawl.

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb structured data across website pages to improve search-result navigation.
* **Improvements**
  * Aligned Open Graph and Twitter previews with each page’s localized title and description.
  * Improved homepage metadata consistency across English and French locales.
  * Preserved concise page descriptions for better social sharing and search display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->