### PR TITLE
fix: save crew and cast before redirecting when creating new dubbing project

### DIFF
--- a/.changeset/fix-cast-crew-before-redirect.md
+++ b/.changeset/fix-cast-crew-before-redirect.md
@@ -1,0 +1,5 @@
+---
+"@app/website": patch
+---
+
+Fix crew and cast data being lost when creating a new dubbing project on movie and show edit pages. Crew and cast are now saved before the redirect.

--- a/apps/website/src/pages/movie/[movieId]/edit/[projectId].vue
+++ b/apps/website/src/pages/movie/[movieId]/edit/[projectId].vue
@@ -676,17 +676,13 @@ const saveMovieProject = async () => {
 
     let projectId = isEditMode.value ? Number(projectIdParam) : null;
 
+    const isNewProject = !isEditMode.value;
+
     if (isEditMode.value && projectId) {
       await supabase.from("dubbing_projects").update(projectPayload).eq("id", projectId);
     } else {
       const { data } = await supabase.from("dubbing_projects").insert([projectPayload]).select().single();
       projectId = data?.id;
-      
-      if (projectId && contentId.value) {
-        showToast("Project created! Redirecting...", "success");
-        router.push(localePath(`/movie/${contentId.value}/edit/${projectId}`));
-        return;
-      }
     }
 
     if (!projectId) throw new Error("No project ID returned");
@@ -727,7 +723,12 @@ const saveMovieProject = async () => {
       await supabase.from("work").upsert([workPayload]);
     }
 
-    showToast("Project saved successfully!", "success");
+    if (isNewProject && contentId.value) {
+      showToast("Project created! Redirecting...", "success");
+      router.push(localePath(`/movie/${contentId.value}/edit/${projectId}`));
+    } else {
+      showToast("Project saved successfully!", "success");
+    }
   } catch (err: any) {
     showToast(err.message, "error");
   } finally {

--- a/apps/website/src/pages/movie/[movieId]/edit/[projectId].vue
+++ b/apps/website/src/pages/movie/[movieId]/edit/[projectId].vue
@@ -679,9 +679,11 @@ const saveMovieProject = async () => {
     const isNewProject = !isEditMode.value;
 
     if (isEditMode.value && projectId) {
-      await supabase.from("dubbing_projects").update(projectPayload).eq("id", projectId);
+      const { error } = await supabase.from("dubbing_projects").update(projectPayload).eq("id", projectId);
+      if (error) throw new Error(`Failed to update project: ${error.message}`);
     } else {
-      const { data } = await supabase.from("dubbing_projects").insert([projectPayload]).select().single();
+      const { data, error } = await supabase.from("dubbing_projects").insert([projectPayload]).select().single();
+      if (error) throw new Error(`Failed to create project: ${error.message}`);
       projectId = data?.id;
     }
 
@@ -699,10 +701,12 @@ const saveMovieProject = async () => {
     ].filter(j => j.person_id !== null);
 
     // Delete old crew & insert new
-    await supabase.from("dubbing_project_crew").delete().eq("dubbing_project_id", projectId);
+    const { error: deleteCrewError } = await supabase.from("dubbing_project_crew").delete().eq("dubbing_project_id", projectId);
+    if (deleteCrewError) throw new Error(`Failed to clear crew: ${deleteCrewError.message}`);
     if (crewJobs.length > 0) {
       const crewPayload = crewJobs.map(j => ({ dubbing_project_id: projectId!, job_id: j.job_id, person_id: j.person_id }));
-      await supabase.from("dubbing_project_crew").insert(crewPayload);
+      const { error: insertCrewError } = await supabase.from("dubbing_project_crew").insert(crewPayload);
+      if (insertCrewError) throw new Error(`Failed to save crew: ${insertCrewError.message}`);
     }
 
     // Save Works (Cast)
@@ -720,7 +724,8 @@ const saveMovieProject = async () => {
         highlight: row.highlight ? true : false,
       };
       if (row.id) workPayload.id = row.id;
-      await supabase.from("work").upsert([workPayload]);
+      const { error: upsertWorkError } = await supabase.from("work").upsert([workPayload]);
+      if (upsertWorkError) throw new Error(`Failed to save cast: ${upsertWorkError.message}`);
     }
 
     if (isNewProject && contentId.value) {

--- a/apps/website/src/pages/show/[showId]/edit/[projectId].vue
+++ b/apps/website/src/pages/show/[showId]/edit/[projectId].vue
@@ -687,9 +687,11 @@ const saveShowProject = async () => {
     const isNewProject = !isEditMode.value;
 
     if (isEditMode.value && projectId) {
-      await supabase.from("dubbing_projects").update(projectPayload).eq("id", projectId);
+      const { error } = await supabase.from("dubbing_projects").update(projectPayload).eq("id", projectId);
+      if (error) throw new Error(`Failed to update project: ${error.message}`);
     } else {
-      const { data } = await supabase.from("dubbing_projects").insert([projectPayload]).select().single();
+      const { data, error } = await supabase.from("dubbing_projects").insert([projectPayload]).select().single();
+      if (error) throw new Error(`Failed to create project: ${error.message}`);
       projectId = data?.id;
     }
 
@@ -707,10 +709,12 @@ const saveShowProject = async () => {
     ].filter(j => j.person_id !== null);
 
     // Delete old crew & insert new
-    await supabase.from("dubbing_project_crew").delete().eq("dubbing_project_id", projectId);
+    const { error: deleteCrewError } = await supabase.from("dubbing_project_crew").delete().eq("dubbing_project_id", projectId);
+    if (deleteCrewError) throw new Error(`Failed to clear crew: ${deleteCrewError.message}`);
     if (crewJobs.length > 0) {
       const crewPayload = crewJobs.map(j => ({ dubbing_project_id: projectId!, job_id: j.job_id, person_id: j.person_id }));
-      await supabase.from("dubbing_project_crew").insert(crewPayload);
+      const { error: insertCrewError } = await supabase.from("dubbing_project_crew").insert(crewPayload);
+      if (insertCrewError) throw new Error(`Failed to save crew: ${insertCrewError.message}`);
     }
 
     // Save Works (Cast)
@@ -728,7 +732,8 @@ const saveShowProject = async () => {
         highlight: row.highlight ? true : false,
       };
       if (row.id) workPayload.id = row.id;
-      await supabase.from("work").upsert([workPayload]);
+      const { error: upsertWorkError } = await supabase.from("work").upsert([workPayload]);
+      if (upsertWorkError) throw new Error(`Failed to save cast: ${upsertWorkError.message}`);
     }
 
     if (isNewProject && contentId.value) {

--- a/apps/website/src/pages/show/[showId]/edit/[projectId].vue
+++ b/apps/website/src/pages/show/[showId]/edit/[projectId].vue
@@ -684,17 +684,13 @@ const saveShowProject = async () => {
 
     let projectId = isEditMode.value ? Number(projectIdParam) : null;
 
+    const isNewProject = !isEditMode.value;
+
     if (isEditMode.value && projectId) {
       await supabase.from("dubbing_projects").update(projectPayload).eq("id", projectId);
     } else {
       const { data } = await supabase.from("dubbing_projects").insert([projectPayload]).select().single();
       projectId = data?.id;
-      
-      if (projectId && contentId.value) {
-        showToast("Project created! Redirecting...", "success");
-        router.push(localePath(`/show/${contentId.value}/edit/${projectId}`));
-        return;
-      }
     }
 
     if (!projectId) throw new Error("No project ID returned");
@@ -735,7 +731,12 @@ const saveShowProject = async () => {
       await supabase.from("work").upsert([workPayload]);
     }
 
-    showToast("Project saved successfully!", "success");
+    if (isNewProject && contentId.value) {
+      showToast("Project created! Redirecting...", "success");
+      router.push(localePath(`/show/${contentId.value}/edit/${projectId}`));
+    } else {
+      showToast("Project saved successfully!", "success");
+    }
   } catch (err: any) {
     showToast(err.message, "error");
   } finally {


### PR DESCRIPTION
## Bug

When saving a movie or show with cast on a media that doesn't already have a dubbing project, cast and crew data was lost. The save function created the project, then immediately redirected via `return`, skipping the crew and cast saving code entirely.

## Fix

Moved crew and cast saving **before** the redirect in both movie and show edit pages. Now the flow is:

1. Insert/update the dubbing project (includes studio, language, status)
2. Save crew (all 7 job roles)
3. Save cast (voice actors, character names, performance type)
4. Only then redirect (new project) or show success toast (edit)

## Files changed

- `apps/website/src/pages/movie/[movieId]/edit/[projectId].vue`
- `apps/website/src/pages/show/[showId]/edit/[projectId].vue`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Movie and show projects now reliably save crew and cast information before redirecting.
  * Database save errors now display clear failure notifications.
  * Project creation displays a confirmation message and opens the project’s edit page.
  * Updates to existing projects show a clear save-success message without unnecessary redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->