### PR TITLE
fix: bump compatibility date for cloudflare-module preset resolution

### DIFF
--- a/apps/website/nuxt.config.ts
+++ b/apps/website/nuxt.config.ts
@@ -4,7 +4,7 @@ import { defineNuxtConfig } from "nuxt/config";
 
 export default defineNuxtConfig({
   rootDir: resolve(import.meta.dirname),
-  compatibilityDate: "2024-04-03",
+  compatibilityDate: "2024-09-23",
 
   app: {
     head: {

--- a/apps/website/wrangler.toml
+++ b/apps/website/wrangler.toml
@@ -1,6 +1,6 @@
 name = "dubbingbase-website"
 main = ".output/server/index.mjs"
-compatibility_date = "2024-04-03"
+compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 
 [assets]


### PR DESCRIPTION
Follow-up to #36.

Nitro's `resolvePreset` filters candidate presets by `compatibilityDate`: with `2024-04-03`, the modern `cloudflare-module` preset (requires ≥ 2024-09-19) was disqualified and nitro silently fell back to `cloudflare-module-legacy`, whose worker imports the Workers-Sites module `__STATIC_CONTENT_MANIFEST` — causing the deploy error `No such module "__STATIC_CONTENT_MANIFEST"` despite native assets being uploaded.

Bumps compatibility date to 2024-09-23 in both wrangler.toml and nuxt.config.ts.